### PR TITLE
(MAINT) Fix user install bug

### DIFF
--- a/lib/litmus_spec.js
+++ b/lib/litmus_spec.js
@@ -16,7 +16,7 @@ async function run() {
         await util.wrappedExec('git config --system core.longpaths true');
       }
       await util.wrappedExec('gem --version');
-      await util.wrappedExec('gem install --user-install bundler');
+      await util.wrappedExec('gem install bundler');
       await util.wrappedExec('bundle -v');
       await util.wrappedExec(`bundle install --jobs 4 --retry 2 ${bundler_args}`);
 


### PR DESCRIPTION
When using the `--user-install` switch on the gem install, the bundler
gem is installed to a user folder path that is not on the PATH variable.
This causes later calls to things like `bundle -v` to fail the build.